### PR TITLE
Fix the order of getting tokens until after cache miss

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 
 	<artifactId>keycloak</artifactId>
-	<version>2.3.1.1-di2e-SNAPSHOT</version>
+	<version>2.3.1.2-di2e-SNAPSHOT</version>
 	<name>Keycloak Authentication Plugin</name>
 	<description>Integrates with Keycloak Authentication</description>
 	<packaging>hpi</packaging>

--- a/src/main/java/org/jenkinsci/plugins/KeycloakAccess.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakAccess.java
@@ -52,7 +52,7 @@ public class KeycloakAccess {
 				List<GrantedAuthority> authorities = getAuthorities( getRolesForUser( username, null ) );
 				return new KeycloakUserDetails( username, authorities.toArray( new GrantedAuthority[0] ) );
 			} else {
-				throw new UsernameNotFoundException( username + " not found in keycloak");
+				throw new DataRetrievalFailureException( "Unable to get user information from Keycloak for " + username );
 			}
 		} catch (UsernameNotFoundException e) {
 			cache.addInvalidUser( username );

--- a/src/main/java/org/jenkinsci/plugins/KeycloakCache.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakCache.java
@@ -82,7 +82,7 @@ public class KeycloakCache {
 		synchronized (invalidUserMap) {
 			CacheEntry<Boolean> invalidUserData = invalidUserMap.get( username );
 			if (invalidUserData != null && invalidUserData.isValid()) {
-				LOGGER.info(username + " is invalid: " + invalidUserData.getValue());
+				LOGGER.fine(username + " is invalid: " + invalidUserData.getValue());
 				return invalidUserData.getValue();
 			}
 		}
@@ -91,7 +91,7 @@ public class KeycloakCache {
 
 	public void addInvalidUser(String username) {
 		synchronized (invalidUserMap) {
-			LOGGER.info( "Adding invalid user: " + username );
+			LOGGER.fine( "Caching invalid user: " + username );
 			CacheEntry<Boolean> invalidUserData = new CacheEntry<>( ttlSec, true );
 			invalidUserMap.put( username, invalidUserData );
 		}


### PR DESCRIPTION
Change to not get Keycloak token unless we really need to do a query.
Update username lookup logging to be fine as to not spam logs with usernames that won't be found due to git plugin