### PR TITLE
Ability to Clear Cache and Use Keycloak Refresh Token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 
 	<artifactId>keycloak</artifactId>
-	<version>2.3.1.3-di2e-SNAPSHOT</version>
+	<version>2.3.1.4-di2e-SNAPSHOT</version>
 	<name>Keycloak Authentication Plugin</name>
 	<description>Integrates with Keycloak Authentication</description>
 	<packaging>hpi</packaging>

--- a/src/main/java/org/jenkinsci/plugins/KeycloakAccess.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakAccess.java
@@ -22,6 +22,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.util.EntityUtils;
@@ -277,17 +278,22 @@ public class KeycloakAccess {
 		String clientId = keycloakDeployment.getResourceName();
 		String secret = (String)keycloakDeployment.getResourceCredentials().get("secret");
 		Http http = new Http(getKeycloakConfig(), (params, headers) -> {});
-		return http.<AccessTokenResponse>post(url)
-			.authentication()
-				.client()
-			.form()
-				.param("grant_type", "refresh_token")
-				.param("refresh_token", refreshToken)
-				.param("client_id", clientId)
-				.param("client_secret", secret)
-			.response()
-			.json(AccessTokenResponse.class)
-			.execute();
+		try {
+			return http.<AccessTokenResponse>post(url)
+				.authentication()
+					.client()
+				.form()
+					.param("grant_type", "refresh_token")
+					.param("refresh_token", refreshToken)
+					.param("client_id", clientId)
+					.param("client_secret", secret)
+				.response()
+				.json(AccessTokenResponse.class)
+				.execute();
+		} catch ( Exception e ) {
+			LOGGER.log(Level.INFO, "Unable to renew token with Keycloak", e);
+			return null;
+		}
 	}
 
 	private Configuration getKeycloakConfig() {

--- a/src/main/java/org/jenkinsci/plugins/KeycloakCache.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakCache.java
@@ -64,12 +64,14 @@ public class KeycloakCache {
 
 	public Collection<String> getRoles() {
 		if (roleCache != null && roleCache.isValid()) {
+			LOGGER.finest("Returning data from Role Cache");
 			return roleCache.getValue();
 		}
 		return null;
 	}
 
 	public void setRoles(Collection<String> roles) {
+		LOGGER.finest("Updating role cache");
 		roleCache = new CacheEntry<>( ttlSec, roles );
 	}
 
@@ -117,6 +119,17 @@ public class KeycloakCache {
 			}
 			return null;
 		}
+	}
+
+	public void clearCache() {
+		synchronized (rolesByUserCache) {
+			rolesByUserCache.clear();
+		}
+		synchronized (invalidUserMap) {
+			invalidUserMap.clear();
+		}
+		roleCache = null;
+		tokenExpiration = 0;
 	}
 
 	private static class CacheEntry<T> {

--- a/src/main/java/org/jenkinsci/plugins/KeycloakCache.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakCache.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import org.keycloak.representations.AccessTokenResponse;
 
 public class KeycloakCache {
 	private static KeycloakCache instance = new KeycloakCache();
@@ -22,9 +23,7 @@ public class KeycloakCache {
 
 	private boolean initialized = false;
 
-	private String token = null;
-
-	private long tokenExpiration = 0;
+	private SystemTokenInfo systemToken = null;
 
 	private static final Object TOKEN_LOCK = new Object();
 
@@ -105,19 +104,15 @@ public class KeycloakCache {
 		}
 	}
 
-	public void setSystemToken(String token, long tokenExpiration) {
+	public void storeSystemAccessToken( SystemTokenInfo systemToken ) {
 		synchronized (TOKEN_LOCK) {
-			this.token = token;
-			this.tokenExpiration = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis( tokenExpiration ) - 500; //include 500ms buffer
+			this.systemToken = systemToken;
 		}
 	}
 
-	public String getSystemToken() {
+	public SystemTokenInfo getSystemAccessToken() {
 		synchronized (TOKEN_LOCK) {
-			if ( token != null && System.currentTimeMillis() < tokenExpiration ) {
-				return token;
-			}
-			return null;
+			return systemToken;
 		}
 	}
 
@@ -129,7 +124,6 @@ public class KeycloakCache {
 			invalidUserMap.clear();
 		}
 		roleCache = null;
-		tokenExpiration = 0;
 	}
 
 	private static class CacheEntry<T> {

--- a/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
@@ -429,6 +429,12 @@ public class KeycloakSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 //			}
 //			return FormValidation.ok();
 //		}
+
+
+		public FormValidation doClearCache() {
+			KeycloakCache.getInstance().clearCache();
+			return FormValidation.ok();
+		}
 	}
 
 	/**

--- a/src/main/java/org/jenkinsci/plugins/SystemTokenInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/SystemTokenInfo.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins;
+
+import java.util.concurrent.TimeUnit;
+import org.keycloak.representations.AccessTokenResponse;
+
+public class SystemTokenInfo {
+	private AccessTokenResponse accessToken;
+	private long tokenExpirationTime = 0;
+	private long refreshTokenExpirationTime = 0;
+
+	public SystemTokenInfo(AccessTokenResponse accessToken) {
+		setAccessToken( accessToken );
+	}
+
+	public AccessTokenResponse getAccessToken() {
+		return accessToken;
+	}
+
+	public void setAccessToken( AccessTokenResponse accessToken ) {
+		this.accessToken = accessToken;
+		//include 500ms buffer
+		this.tokenExpirationTime =
+			System.currentTimeMillis() + TimeUnit.SECONDS.toMillis( accessToken.getExpiresIn() ) - 500;
+		this.refreshTokenExpirationTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis( accessToken.getRefreshExpiresIn() ) - 500;
+	}
+
+	public long getTokenExpirationTime() {
+		return tokenExpirationTime;
+	}
+
+	public long getRefreshTokenExpirationTime() {
+		return refreshTokenExpirationTime;
+	}
+}

--- a/src/main/resources/org/jenkinsci/plugins/KeycloakSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/KeycloakSecurityRealm/config.jelly
@@ -26,5 +26,6 @@
 		<f:entry field="cacheTtlSecStr" title="Cache TTL (Seconds)">
 			<f:textbox default="300"/>
 		</f:entry>
+		<f:validateButton title="Clear Cache" method="clearCache" />
 	</f:advanced>
 </j:jelly>


### PR DESCRIPTION
Adds a Clear Cache button in Configure Global Security -> Keycloak Auth Plugin -> Advanced -> Clear Cache
Uses Keycloak Refresh token in order to continue to reuse same session until the session expires. Further reduces the number of sessions created in Keycloak.
